### PR TITLE
Rebuild PHP affiliate manager without dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# gerenciadordeafiliados
+# Gerenciador de Afiliados
+
+Sistema simples em PHP puro que gera páginas com produtos afiliados. Cada produto possui um link de afiliado, imagem em base64 e um QR code. As páginas também exibem um QR code para fácil compartilhamento.
+
+## Banco de Dados
+Crie um banco MariaDB/MySQL e execute os comandos:
+
+```sql
+CREATE TABLE tb_pagina_afiliados (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    titulo VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) UNIQUE NOT NULL
+);
+
+CREATE TABLE tb_produto (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    url_afiliado TEXT NOT NULL,
+    preco DECIMAL(10,2) NOT NULL,
+    imagem VARCHAR(255) DEFAULT NULL
+);
+
+CREATE TABLE tb_pagina_produto (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    pagina_id INT NOT NULL,
+    produto_id INT NOT NULL,
+    FOREIGN KEY (pagina_id) REFERENCES tb_pagina_afiliados(id) ON DELETE CASCADE,
+    FOREIGN KEY (produto_id) REFERENCES tb_produto(id) ON DELETE CASCADE
+);
+```
+
+## Configuração e Execução
+1. Ajuste as credenciais de banco em `index.php` e `admin.php`.
+2. Coloque o projeto no diretório público do seu servidor (ex.: `htdocs` do XAMPP) ou use o servidor embutido do PHP:
+   ```bash
+   php -S localhost:8000 -t .
+   ```
+3. Acesse `admin.php` para criar páginas e cadastrar produtos.
+4. Acesse `index.php?slug=SLUG_DA_PAGINA` para visualizar a página pública.
+
+Os QR codes são gerados através do serviço gratuito `api.qrserver.com`.

--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,148 @@
+<?php
+// Painel administrativo simples
+$host = 'localhost';
+$db   = 'afiliados';
+$user = 'root';
+$pass = '';
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+// Create new page
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_page'])) {
+    $title = trim($_POST['page_title'] ?? '');
+    $slug  = trim($_POST['page_slug'] ?? '');
+    if ($title && $slug) {
+        $stmt = $pdo->prepare('INSERT INTO tb_pagina_afiliados (titulo, slug) VALUES (?, ?)');
+        $stmt->execute([$title, $slug]);
+    }
+}
+
+// Create new product
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_product'])) {
+    $pageId = (int)($_POST['page_id'] ?? 0);
+    $name   = trim($_POST['product_name'] ?? '');
+    $link   = trim($_POST['affiliate_link'] ?? '');
+    $price  = str_replace(',', '.', $_POST['price'] ?? '0');
+    $imageBase64 = '';
+    if (!empty($_FILES['image']['tmp_name'])) {
+        $mime = mime_content_type($_FILES['image']['tmp_name']);
+        $data = base64_encode(file_get_contents($_FILES['image']['tmp_name']));
+        $imageBase64 = 'data:' . $mime . ';base64,' . $data;
+    }
+    if ($pageId && $name && $link) {
+        $stmt = $pdo->prepare('INSERT INTO tb_produto (nome, url_afiliado, preco, imagem) VALUES (?,?,?,?)');
+        $stmt->execute([$name, $link, (float)$price, $imageBase64]);
+        $prodId = $pdo->lastInsertId();
+        $stmt = $pdo->prepare('INSERT INTO tb_pagina_produto (pagina_id, produto_id) VALUES (?, ?)');
+        $stmt->execute([$pageId, $prodId]);
+    }
+}
+
+$pages = $pdo->query('SELECT id, titulo FROM tb_pagina_afiliados ORDER BY titulo')->fetchAll(PDO::FETCH_ASSOC);
+$products = $pdo->query('SELECT pr.id, pr.nome, pr.url_afiliado, pr.preco, pr.imagem, pa.titulo AS page_title
+                          FROM tb_produto pr
+                          JOIN tb_pagina_produto pp ON pr.id = pp.produto_id
+                          JOIN tb_pagina_afiliados pa ON pp.pagina_id = pa.id
+                          ORDER BY pr.id DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Painel Admin</title>
+    <style>
+        * { margin:0; padding:0; box-sizing:border-box; }
+        body { font-family:'Segoe UI', sans-serif; background:#fefcfb; color:#2c2c2c; padding:20px; }
+        h1 { font-size:2rem; color:#6f5d90; margin-bottom:20px; text-align:center; }
+        form { margin-bottom:40px; background:#fff; padding:20px; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.05); }
+        form div { margin-bottom:10px; }
+        label { display:block; margin-bottom:5px; }
+        input[type="text"], input[type="url"], select { width:100%; padding:8px; border:1px solid #ccc; border-radius:4px; }
+        input[type="file"] { border:1px solid #ccc; padding:8px; border-radius:4px; width:100%; }
+        button { background:#8c7dbf; color:#fff; border:none; padding:10px 20px; border-radius:8px; cursor:pointer; }
+        button:hover { background:#7a6ab0; }
+        table { width:100%; border-collapse:collapse; margin-top:20px; }
+        th, td { border:1px solid #ddd; padding:10px; text-align:center; }
+        th { background:#eee; }
+        img { max-width:100px; }
+    </style>
+</head>
+<body>
+    <h1>Painel Administrativo</h1>
+
+    <form method="post">
+        <h2>Nova Página</h2>
+        <div>
+            <label for="page_title">Título da página</label>
+            <input type="text" id="page_title" name="page_title" required>
+        </div>
+        <div>
+            <label for="page_slug">Slug</label>
+            <input type="text" id="page_slug" name="page_slug" required>
+        </div>
+        <button type="submit" name="create_page">Criar Página</button>
+    </form>
+
+    <form method="post" enctype="multipart/form-data">
+        <h2>Novo Produto</h2>
+        <div>
+            <label for="page_id">Página</label>
+            <select name="page_id" id="page_id" required>
+                <option value="">Selecione</option>
+                <?php foreach ($pages as $p): ?>
+                    <option value="<?= $p['id'] ?>"><?= htmlspecialchars($p['titulo']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div>
+            <label for="product_name">Nome do produto</label>
+            <input type="text" id="product_name" name="product_name" required>
+        </div>
+        <div>
+            <label for="affiliate_link">Link de afiliado</label>
+            <input type="url" id="affiliate_link" name="affiliate_link" required>
+        </div>
+        <div>
+            <label for="price">Preço</label>
+            <input type="text" id="price" name="price" required>
+        </div>
+        <div>
+            <label for="image">Imagem</label>
+            <input type="file" id="image" name="image" accept="image/*" required>
+        </div>
+        <button type="submit" name="create_product">Adicionar Produto</button>
+    </form>
+
+    <h2>Produtos cadastrados</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Página</th>
+                <th>Produto</th>
+                <th>Preço</th>
+                <th>Imagem</th>
+                <th>Link</th>
+                <th>QR</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($products as $prod): ?>
+            <tr>
+                <td><?= htmlspecialchars($prod['page_title']) ?></td>
+                <td><?= htmlspecialchars($prod['nome']) ?></td>
+                <td>R$ <?= number_format($prod['preco'], 2, ',', '.') ?></td>
+                <td><?php if ($prod['imagem']): ?><img src="<?= $prod['imagem'] ?>" alt="<?= htmlspecialchars($prod['nome']) ?>"><?php endif; ?></td>
+                <td><a href="<?= htmlspecialchars($prod['url_afiliado']) ?>" target="_blank">Link</a></td>
+                <td><img src="https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=<?= urlencode($prod['url_afiliado']) ?>" alt="QR"></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,81 @@
+<?php
+// Simple affiliate page display without frameworks or composer
+// Adjust database credentials as needed
+$host = 'localhost';
+$db   = 'afiliados';
+$user = 'root';
+$pass = '';
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+// Load page by slug
+$slug = trim($_GET['slug'] ?? '');
+if ($slug === '') {
+    die('Página não encontrada');
+}
+
+// Fetch page
+$stmt = $pdo->prepare('SELECT id, titulo, slug FROM tb_pagina_afiliados WHERE slug = ?');
+$stmt->execute([$slug]);
+$page = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$page) {
+    die('Página não encontrada');
+}
+
+// Fetch products for page
+$stmt = $pdo->prepare('SELECT pr.nome, pr.url_afiliado, pr.preco, pr.imagem
+                        FROM tb_produto pr
+                        JOIN tb_pagina_produto pp ON pr.id = pp.produto_id
+                        WHERE pp.pagina_id = ?');
+$stmt->execute([$page['id']]);
+$products = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
+$pageUrl = $baseUrl . '?slug=' . urlencode($page['slug']);
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($page['titulo']) ?></title>
+    <style>
+        * { margin:0; padding:0; box-sizing:border-box; }
+        body { font-family:'Segoe UI', sans-serif; background-color:#fefcfb; color:#2c2c2c; padding:20px; }
+        .container { max-width:900px; margin:0 auto; }
+        h1 { font-size:2rem; color:#6f5d90; margin-bottom:20px; }
+        .product { border:1px solid #ddd; padding:20px; border-radius:8px; margin-bottom:20px; text-align:center; }
+        .product img { max-width:200px; display:block; margin:0 auto 10px; }
+        .qr { margin-top:10px; }
+        .page-qr { text-align:right; margin-bottom:20px; }
+        a.cta { display:inline-block; background:#8c7dbf; color:#fff; padding:10px 20px; border-radius:8px; text-decoration:none; }
+        a.cta:hover { background:#7a6ab0; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="page-qr">
+        <img src="https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=<?= urlencode($pageUrl) ?>" alt="QR da página">
+    </div>
+    <h1><?= htmlspecialchars($page['titulo']) ?></h1>
+    <?php foreach ($products as $prod): ?>
+        <div class="product">
+            <?php if ($prod['imagem']): ?>
+                <img src="<?= $prod['imagem'] ?>" alt="<?= htmlspecialchars($prod['nome']) ?>">
+            <?php endif; ?>
+            <h2><?= htmlspecialchars($prod['nome']) ?></h2>
+            <p><strong>Preço:</strong> R$ <?= number_format($prod['preco'], 2, ',', '.') ?></p>
+            <a class="cta" href="<?= htmlspecialchars($prod['url_afiliado']) ?>" target="_blank">Comprar</a>
+            <div class="qr">
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=<?= urlencode($prod['url_afiliado']) ?>" alt="QR de <?= htmlspecialchars($prod['nome']) ?>">
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- adopt `tb_pagina_afiliados`, `tb_produto` and `tb_pagina_produto` tables with slugged pages and product pricing
- load public pages by slug and list joined products with QR codes and base64 images
- expand admin panel to create pages with slugs and products with price, saving images in base64 and linking them to pages

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68c0290604ec832581d1ee323a6c75e6